### PR TITLE
fix: skip game folder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -86,19 +86,24 @@ const dirTree = folderName => {
     throw "Expected a folder but received a file!"
   }
 
-  fs.readdirSync(folderName).map(fileName => {
-    const isDeprecatedFile = deprecatedFiles.indexOf(`${fileName}`) >= 0
-    const isIgnoredFile = fileName === "index.json" || fileName[0] === "."
-    if (!isIgnoredFile && !isDeprecatedFile) {
-      const file = getFileDetails(`${folderName}/${fileName}`)
-      if (!file.isResponsive) {
-        index.push(file)
-        if (file.type === "folder") {
-          dirTree(`${folderName}/${fileName}`, deprecatedFiles)
+  fs.readdirSync(folderName)
+    // TODO: Remove this .filter step once Rune Games are located on a different CDN
+    .filter(
+      fileName => !`${folderName}/${fileName}`.endsWith("vivid-launchpad/game")
+    )
+    .map(fileName => {
+      const isDeprecatedFile = deprecatedFiles.indexOf(`${fileName}`) >= 0
+      const isIgnoredFile = fileName === "index.json" || fileName[0] === "."
+      if (!isIgnoredFile && !isDeprecatedFile) {
+        const file = getFileDetails(`${folderName}/${fileName}`)
+        if (!file.isResponsive) {
+          index.push(file)
+          if (file.type === "folder") {
+            dirTree(`${folderName}/${fileName}`, deprecatedFiles)
+          }
         }
       }
-    }
-  })
+    })
 
   fs.writeFile(
     `${folderName}/index.json`,


### PR DESCRIPTION
Closes RUNE-5296

The GitHub Action has been failing since we started adding content to the `game/` folder. Let's just skip indexing the `game/` folder since that content will be moving to a different CDN at some point.