### PR TITLE
fix: dubious ownership

### DIFF
--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -9,6 +9,7 @@ node index.js $GITHUB_WORKSPACE
 
 # Commit and push generated indices
 cd $GITHUB_WORKSPACE
+git config --global --add safe.directory $GITHUB_WORKSPACE
 git config --global user.name "${INPUT_CI_USERNAME}"
 git config --global user.email "${INPUT_CI_EMAIL}"
 git add .

--- a/src/index.js
+++ b/src/index.js
@@ -109,8 +109,12 @@ const dirTree = (folderName) => {
     `${folderName}/index.json`,
     JSON.stringify(index, null, 2),
     "utf8",
-    () => {
-      console.log(`Index written for ${folderName}`)
+    (err) => {
+      if (err) {
+        console.err(`Index not written for ${folderName}`, err)
+      } else {
+        console.log(`Index written for ${folderName}`)
+      }
     }
   )
 


### PR DESCRIPTION
Indexer started failing most likely due to https://github.blog/2022-04-12-git-security-vulnerability-announced/: 

Here are logs:
```sh
Index written for /github/workspace/img
Index written for /github/workspace
fatal: detected dubious ownership in repository at '/github/workspace'
To add an exception for this directory, call:

	git config --global --add safe.directory /github/workspace
```

Adding `safe.directory` fixed the issue.

### Test plan

- [x] Run Indexer Github Action on another repository and make sure it succeeds